### PR TITLE
Create B2MML-OperationsTest.xsd

### DIFF
--- a/Schema/B2MML-OperationsTest.xsd
+++ b/Schema/B2MML-OperationsTest.xsd
@@ -166,7 +166,7 @@ of test specifications.
                                                         minOccurs = "0"/>
       <xsd:element name = "RecurrenceTimeInterval"	type = "DurationType"
                                                         minOccurs = "0"/>
-      <xsd:element name = "PhysicalSample"		type = "IndicatorType"
+      <xsd:element name = "PhysicalSampleRequired"	type = "IndicatorType"
                                                         minOccurs = "0"/>
       <xsd:element name = "TestSpecificationChild"    	type = "TestSpecificationType" 
                                                         minOccurs = "0" maxOccurs = "unbounded"/>


### PR DESCRIPTION
**Background**
#16 This new schema creates an OperationsTest.xsd schema that has test specification type and test result type and allow 1st order transactions so that it aligns with updated 950002.  This schema replaces TestSpecification.xsd and TestResultType in Common Schema.  
But the updated 950002 as part of the collaboration with OAGi viewed Test Results as a 1st order object and transactions.
B2MML 7.0 beta has created a B2MML-TestSpecification.xsd schema and created the complex types of "TestResultType" and TestPropertyMeasurementType in the Common Schema.
B2MML 7.0 still has the TestResult type as an attribute in each instance resource property per the old version of ISA-95 resource models and B2MML 6.0. This was a composite relationship which did not allow Test Result to be exchanged and queried as a 1st class object.
In the new Operations Test Model in updated 950002, Test Result is a 1st order object that is able to be exchanged/queried.
The MESA Committee may reject changing their implementation. If so,