### PR TITLE
Update B2MML-Common.xsd

### DIFF
--- a/Schema/B2MML-Common.xsd
+++ b/Schema/B2MML-Common.xsd
@@ -983,13 +983,15 @@ This attribute must be defined in the corresponding operations event definition.
     <!--     -->    
     <xsd:complexType name="OpEquipmentRequirementPropertyType">
         <xsd:sequence>
-            <xsd:element name="ID" type="IdentifierType"/>
-            <xsd:element name="Description" type="DescriptionType" minOccurs="0" maxOccurs="unbounded"/>
-            <xsd:element name="Value" type="ValueType" minOccurs="0" maxOccurs="unbounded"/>
-            <xsd:element name="Quantity" type="QuantityValueType" minOccurs="0" maxOccurs="unbounded"/>
-	    <xsd:element name="PersonnelClassPropertyID" 	type="IdentifierType" minOccurs="0"/>
-            <xsd:element name="PersonPropertyID" 		type="IdentifierType" minOccurs="0"/>	
-            <xsd:element name="EquipmentRequirementPropertyChild" type="OpEquipmentRequirementPropertyType" minOccurs="0" maxOccurs="unbounded"/>
+            <xsd:element name="ID" 			type="IdentifierType"/>
+            <xsd:element name="Description" 		type="DescriptionType" minOccurs="0" maxOccurs="unbounded"/>
+            <xsd:element name="Value" 			type="ValueType" minOccurs="0" maxOccurs="unbounded"/>
+            <xsd:element name="Quantity" 		type="QuantityValueType" minOccurs="0" maxOccurs="unbounded"/>
+	    <xsd:element name="EquipmentClassPropertyID" 
+			 				type="IdentifierType" minOccurs="0"/>
+            <xsd:element name="EquipmentPropertyID" 	type="IdentifierType" minOccurs="0"/>	
+            <xsd:element name="EquipmentRequirementPropertyChild" 
+			 				type="OpEquipmentRequirementPropertyType" minOccurs="0" maxOccurs="unbounded"/>
             <xsd:group ref="Extended:OpEquipmentRequirementProperty" minOccurs="0" maxOccurs="1"/>
         </xsd:sequence>
     </xsd:complexType>
@@ -1041,8 +1043,10 @@ This attribute must be defined in the corresponding operations event definition.
 	    <xsd:element name="PhysicalLocation" 		type="ResourceLocationType" minOccurs = "0" />
             <xsd:element name="EquipmentLevel" 			type="HierarchyScopeType" minOccurs="0"/>
             <xsd:element name="PhysicalAssetRequirementChild" 	type="OpPhysicalAssetRequirementType" minOccurs="0" maxOccurs="unbounded"/>		
-            <xsd:element name="PhysicalAssetRequirementProperty" 	type="OpPhysicalAssetRequirementPropertyType" minOccurs="0" maxOccurs="unbounded"/>
-            <xsd:element name="RequiredByRequestedSegmentResponse" 	type="RequiredByRequestedSegmentResponseType" minOccurs="0"/>
+            <xsd:element name="PhysicalAssetRequirementProperty"
+			 					type="OpPhysicalAssetRequirementPropertyType" minOccurs="0" maxOccurs="unbounded"/>
+            <xsd:element name="RequiredByRequestedSegmentResponse"
+			 					type="RequiredByRequestedSegmentResponseType" minOccurs="0"/>
             <xsd:element name="TestSpecificationID" 		type="IdentifierType" minOccurs="0" maxOccurs="unbounded"/>
             <xsd:group ref="Extended:OpPhysicalAssetRequirement" minOccurs="0" maxOccurs="1"/>
         </xsd:sequence>
@@ -1054,8 +1058,8 @@ This attribute must be defined in the corresponding operations event definition.
             <xsd:element name="Description" 			type="DescriptionType" minOccurs="0" maxOccurs="unbounded"/>
             <xsd:element name="Value" 				type="ValueType" minOccurs="0" maxOccurs="unbounded"/>
             <xsd:element name="Quantity" 			type="QuantityValueType" minOccurs="0" maxOccurs="unbounded"/>
-	    <xsd:element name="PersonnelClassPropertyID" 	type="IdentifierType" minOccurs="0"/>
-            <xsd:element name="PersonPropertyID" 		type="IdentifierType" minOccurs="0"/>	
+	    <xsd:element name="PhysicalAssetClassPropertyID" 	type="IdentifierType" minOccurs="0"/>
+            <xsd:element name="PhysicalAssetPropertyID" 	type="IdentifierType" minOccurs="0"/>	
 	    <xsd:element name="PhysicalAssetRequirementPropertyChild" 
 			 					type="OpPhysicalAssetRequirementPropertyType" minOccurs="0" maxOccurs="unbounded"/>
             <xsd:group ref="Extended:OpPhysicalAssetRequirementProperty" minOccurs="0" maxOccurs="1"/>
@@ -1092,6 +1096,9 @@ This attribute must be defined in the corresponding operations event definition.
             <xsd:element name="Description" 			type="DescriptionType" minOccurs="0" maxOccurs="unbounded"/>
             <xsd:element name="Value" 				type="ValueType" minOccurs="0" maxOccurs="unbounded"/>
             <xsd:element name="Quantity" 			type="QuantityValueType" minOccurs="0" maxOccurs="unbounded"/>
+	    <xsd:element name="MaterialClassPropertyID" 	type="IdentifierType" minOccurs="0"/>
+	    <xsd:element name="MaterialDefinitionPropertyID" 	type="IdentifierType" minOccurs="0"/>
+            <xsd:element name="MaterialLotPropertyID" 		type="IdentifierType" minOccurs="0"/>	
             <xsd:element name="MaterialRequirementPropertyChild" 
 			 					type="OpMaterialRequirementPropertyType" minOccurs="0" maxOccurs="unbounded"/>
             <xsd:group ref="Extended:OpMaterialRequirementProperty" minOccurs="0" maxOccurs="1"/>


### PR DESCRIPTION
ERDi, MESA: #75  complexType name="OpEquipmentRequirementPropertyType, Correction to previous Commit
CHANGE:  
	    <xsd:element name="PersonnelClassPropertyID" 	type="IdentifierType" minOccurs="0"/>
            <xsd:element name="PersonPropertyID" 		type="IdentifierType" minOccurs="0"/>
TO:
	    <xsd:element name="EquipmentClassPropertyID" 	type="IdentifierType" minOccurs="0"/>
            <xsd:element name="EquipmentPropertyID" 		type="IdentifierType" minOccurs="0"/>

ERDi, MESA: #75  complexType name="OpPhysicalAssetRequirementPropertyType"  Correction to previous Commit
CHANGE:  
	    <xsd:element name="PersonnelClassPropertyID" 	type="IdentifierType" minOccurs="0"/>
            <xsd:element name="PersonPropertyID" 		type="IdentifierType" minOccurs="0"/>
TO:
	    <xsd:element name="PhysicalAssetClassPropertyID" 	type="IdentifierType" minOccurs="0"/>
            <xsd:element name="PhysicalAssetPropertyID" 		type="IdentifierType" minOccurs="0"/>

ERDi, MESA: #75  complexType name="OpMaterialRequirementPropertyType"
ADD: 
	    <xsd:element name="MaterialClassPropertyID" 	type="IdentifierType" minOccurs="0"/>
            <xsd:element name="MaterialDefinitionPropertyID" type="IdentifierType" minOccurs="0"/>
            <xsd:element name="MaterialLotPropertyID" 		 type="IdentifierType" minOccurs="0"/>